### PR TITLE
Increase default iterations of PBKDF2 to 100,000.

### DIFF
--- a/src/crypto/password/pbkdf2.clj
+++ b/src/crypto/password/pbkdf2.clj
@@ -26,7 +26,7 @@
 
   All elements in the output string are Base64 encoded."
   ([raw]
-     (encrypt raw 20000))
+     (encrypt raw 100000))
   ([raw iterations]
      (encrypt raw iterations (random/bytes 8)))
   ([raw iterations salt]


### PR DESCRIPTION
20,000 is too low to be a sane default in 2014. According to OWASP the
rule of thumb is to tune the work-factor to make sure the process takes
around 250ms to 1s.

100,000 iterations takes around 241ms on my mid-2012 MacBook Air, so
given modern hardware 100,000 seems to be a fairly sane default.
