### PR TITLE
Bump bcrypt version from 0.7.0 to 0.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [crypto-random "1.2.0"]
                  [crypto-equality "1.0.0"]
                  [commons-codec "1.12"]
-                 [at.favre.lib/bcrypt "0.7.0"]
+                 [at.favre.lib/bcrypt "0.9.0"]
                  [com.lambdaworks/scrypt "1.4.0"]]
   :plugins [[lein-codox "0.9.4"]]
   :codox


### PR DESCRIPTION
Changes:
* bump bcrypt version to 0.9.0