### PR TITLE
Parameterize `crypto.password.scrypt` defaults

### DIFF
--- a/src/crypto/password/bcrypt.clj
+++ b/src/crypto/password/bcrypt.clj
@@ -4,12 +4,15 @@
   See: https://github.com/patrickfav/bcrypt"
   (:import [at.favre.lib.crypto.bcrypt BCrypt]))
 
+(def ^:private default-work-factor
+  (Long/parseLong (System/getProperty "crypto.password.bcrypt.default-work-factor" "11")))
+
 (defn encrypt
   "Encrypt a password string using the BCrypt algorithm. The optional work
   factor is the log2 of the number of hashing rounds to apply. The default
   work factor is 11."
   ([raw]
-   (encrypt raw 11))
+   (encrypt raw default-work-factor))
   ([raw work-factor]
    (.hashToString (BCrypt/withDefaults) work-factor (.toCharArray raw))))
 

--- a/src/crypto/password/pbkdf2.clj
+++ b/src/crypto/password/pbkdf2.clj
@@ -20,6 +20,9 @@
 (defn- encode-int [i]
   (String. (Base64/encodeInteger (BigInteger/valueOf i))))
 
+(def ^:private default-iterations-count
+  (Long/parseLong (System/getProperty "crypto.password.pbkdf2.default-iterations-count" "100000")))
+
 (defn encrypt
   "Encrypt a password string using the PBKDF2 algorithm. The default number of
   iterations is 100,000. If a salt is not specified, 8 random bytes are
@@ -37,7 +40,7 @@
 
   The iterations, salt, and encrypted password are all Base64 encoded."
   ([raw]
-   (encrypt raw 100000))
+   (encrypt raw default-iterations-count))
   ([raw iterations]
    (encrypt raw iterations "HMAC-SHA1"))
   ([raw iterations algorithm]

--- a/src/crypto/password/scrypt.clj
+++ b/src/crypto/password/scrypt.clj
@@ -4,6 +4,15 @@
   See: https://www.tarsnap.com/scrypt/scrypt.pdf"
   (:import com.lambdaworks.crypto.SCryptUtil))
 
+(def ^:private default-cpu-cost
+  (Long/parseLong (System/getProperty "crypto.password.scrypt.default-cpu-cost" "32768")))
+
+(def ^:private default-memory-cost
+  (Long/parseLong (System/getProperty "crypto.password.scrypt.default-memory-cost" "8")))
+
+(def ^:private default-parallelization-parameter
+  (Long/parseLong (System/getProperty "crypto.password.scrypt.default-parallelization-parameter" "1")))
+
 (defn encrypt
   "Encrypt a password string using the scrypt algorithm. This function takes
   three optional parameters:
@@ -12,9 +21,9 @@
   * `r` - the memory cost, defaults to 8
   * `p` - the parallelization parameter, defaults to 1"
   ([raw]
-   (encrypt raw 32768))
+   (encrypt raw default-cpu-cost))
   ([raw n]
-   (encrypt raw n 8 1))
+   (encrypt raw n default-memory-cost default-parallelization-parameter))
   ([raw n r p]
    (SCryptUtil/scrypt raw n r p)))
 


### PR DESCRIPTION
By making the defaults configurable via `System` properties, one can make test-oriented code faster without touching production-oriented code, or third-party dependencies, etc.

---

If this approach is welcome I could also give a similar treatment to the remaining namespaces.